### PR TITLE
Improve README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,38 +17,52 @@ You can see a running version of the application at
 ### Ubuntu Environment
 Instructions for creating a development environment for Ubuntu Linux.  This has been tested using Ubuntu 12.04.
 
-    #Initial libraries needed
-    $ sudo apt-get install build-essential git-core python-software-properties python-dev python-pip python-virtualenv
+```bash
+# Initial libraries needed
+$ sudo apt-get install build-essential git-core python-software-properties python-dev python-pip python-virtualenv
 
-    #PIL Dependencies
-    $ sudo apt-get install build-dep python-imaging
+# PIL Dependencies
+$ sudo apt-get build-dep python-imaging
 
-    Also symlink associated libraries:
-    $ sudo ln -s /usr/lib/`uname -i`-linux-gnu/libfreetype.so /usr/lib/
-    $ sudo ln -s /usr/lib/`uname -i`-linux-gnu/libjpeg.so /usr/lib/
-    $ sudo ln -s /usr/lib/`uname -i`-linux-gnu/libz.so /usr/lib/
+# Also symlink associated libraries:
+$ sudo ln -s /usr/lib/`uname -i`-linux-gnu/libfreetype.so /usr/lib/
+$ sudo ln -s /usr/lib/`uname -i`-linux-gnu/libjpeg.so /usr/lib/
+$ sudo ln -s /usr/lib/`uname -i`-linux-gnu/libz.so /usr/lib/
 
-    # Install PostgreSQL/Postgis
-    $ sudo apt-get install postgresql-9.1
-    $ sudo apt-get install postgresql-9.1-postgis
+# Install PostgreSQL/Postgis
+$ sudo apt-get install postgresql-9.1
+$ sudo apt-get install postgresql-9.1-postgis
+```
 
 ### Mac Environment
-This project uses PostgreSQL/Postgis and the best way to get this setup on the mac is by downloading [Postgres.app]
+This project uses PostgreSQL/PostGIS and the best way to get this set up on Mac is by downloading [Postgres.app].
 
 [Homebrew]: http://mxcl.github.com/homebrew/
 [Postgres.app]: http://postgresapp.com/
 
 ## <a name="installation"></a>Installation
-    git clone git://github.com/codeforamerica/straymapper.git
-    cd straymapper
-    pip install -r requirements.txt
-    ./manage.py syncdb
+```bash
+git clone git://github.com/codeforamerica/straymapper.git
+cd straymapper
+pip install -r requirements.txt
+./manage.py syncdb
+```
+
+This will install all the dependencies listed in [`requirements.txt`](requirements.txt) and set up your database.
 
 ## <a name="usage"></a>Usage
-    ./manage.py runserver
+Start the development server by running:
+```bash
+./manage.py runserver
+```
+
+The application will be available at `http://localhost:8000/`.
 
 ## <a name="seed"></a>Seed Data
-    ./manage.py loaddata animals/fixtures/animals_testdata.json
+To populate your database with sample data for testing, run:
+```bash
+./manage.py loaddata animals/fixtures/animals_testdata.json
+```
 
 ## <a name="contributing"></a>Contributing
 In the spirit of [free software][free-sw], **everyone** is encouraged to help
@@ -80,8 +94,8 @@ submitting a bug report or feature request, check to make sure it hasn't
 already been submitted. You can indicate support for an existing issue by
 voting it up. When submitting a bug report, please include a [Gist][] that
 includes a stack trace and any details that may be necessary to reproduce the
-bug, including your gem version, Ruby version, and operating system. Ideally, a
-bug report should include a pull request with failing specs.
+bug, including your Python version, Django version, and operating system. Ideally, a
+bug report should include a pull request with failing tests.
 
 [gist]: https://gist.github.com/
 
@@ -90,14 +104,17 @@ bug report should include a pull request with failing specs.
 2. Create a topic branch.
 3. Implement your feature or bug fix.
 4. Add tests for your feature or bug fix.
-5. Run `./manage.py test`. If your changes are not 100% covered, go back
-   to step 4.
+5. Run the following command to test your changes:
+   ```bash
+   ./manage.py test
+   ```
+   If your changes are not 100% covered, go back to step 4.
 6. Commit and push your changes.
-7. Submit a pull request. Please do not include changes to the gemspec or
-   version file. (If you want to create your own version for some reason,
+7. Submit a pull request. Please do not include changes to the version
+   file. (If you want to create your own version for some reason,
    please do so in a separate commit.)
 
 ## <a name="copyright"></a>Copyright
 Copyright (c) 2012 Code for America. See [LICENSE][] for details.
 
-[license]: https://github.com/codeforamerica/cfa_template/blob/master/LICENSE.mkd
+[license]: LICENSE.mkd


### PR DESCRIPTION
- Add language annotations to all code blocks (bash)
- Fix Ruby/gem references to be Python/Django specific
- Correct LICENSE link to point to local file instead of external repo
- Add helpful explanatory text for installation and usage sections
- Fix typo: 'Postgis' -> 'PostGIS' and improve Mac setup description
- Make wording more friendly and clear throughout
- Add link to requirements.txt file for better navigation